### PR TITLE
bugfix/accurics_remediation_03763272416166208 - Auto Generated Pull Request From Accurics

### DIFF
--- a/test-aws-ec2-1.tf
+++ b/test-aws-ec2-1.tf
@@ -1,7 +1,8 @@
 resource "aws_instance" "myec2" {
-  ami = "ami-0b0af3577fe5e3532"
+  ami           = "ami-0b0af3577fe5e3532"
   instance_type = "t2.micro"
-  tags={
-      Name = "coco-test-ec2-rh8-1"
+  tags = {
+    Name = "coco-test-ec2-rh8-1"
   }
+  vpc_security_group_ids = ["sg-05096ef7b268469af"]
 }


### PR DESCRIPTION
Amazon Virtual Private Cloud (Amazon VPC) enables you to define a virtual network in your own logically isolated area within the AWS cloud, known as a virtual private cloud or VPC. You can create AWS resources, such as Amazon EC2 instances, into the subnets of your VPC. Your VPC closely resembles a traditional network that you might operate in your own data center, with the benefits of using scalable infrastructure from AWS.